### PR TITLE
updated platinum recipes to use item tags

### DIFF
--- a/src/main/resources/data/wyrmroost/recipes/platinum_axe.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_axe.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     "#": {
       "item": "minecraft:stick"

--- a/src/main/resources/data/wyrmroost/recipes/platinum_block.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_block.json
@@ -2,31 +2,31 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     }
   ],
   "result": {

--- a/src/main/resources/data/wyrmroost/recipes/platinum_boots.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_boots.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     }
   },
   "result": {

--- a/src/main/resources/data/wyrmroost/recipes/platinum_chestplate.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_chestplate.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     }
   },
   "result": {

--- a/src/main/resources/data/wyrmroost/recipes/platinum_dragon_armor.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_dragon_armor.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     "#": {
       "item": "wyrmroost:platinum_block"

--- a/src/main/resources/data/wyrmroost/recipes/platinum_helmet.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_helmet.json
@@ -6,7 +6,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     }
   },
   "result": {

--- a/src/main/resources/data/wyrmroost/recipes/platinum_hoe.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_hoe.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     "#": {
       "item": "minecraft:stick"

--- a/src/main/resources/data/wyrmroost/recipes/platinum_ingot.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_ingot.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "item": "wyrmroost:platinum_ingot"
+      "item": "wyrmroost:platinum_block"
     }
   ],
   "result": {

--- a/src/main/resources/data/wyrmroost/recipes/platinum_leggings.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_leggings.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     }
   },
   "result": {

--- a/src/main/resources/data/wyrmroost/recipes/platinum_pickaxe.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_pickaxe.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     "#": {
       "item": "minecraft:stick"

--- a/src/main/resources/data/wyrmroost/recipes/platinum_shovel.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_shovel.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     "#": {
       "item": "minecraft:stick"

--- a/src/main/resources/data/wyrmroost/recipes/platinum_sword.json
+++ b/src/main/resources/data/wyrmroost/recipes/platinum_sword.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "X": {
-      "item": "wyrmroost:platinum_ingot"
+      "tag": "forge:ingots/platinum"
     },
     "#": {
       "item": "minecraft:stick"


### PR DESCRIPTION
for compatibility with other mods' platinum.

Additionally, fixed a duplication bug wherein 1 platinum ingot could be crafted into 9 other platinum ingots. It looks like this was supposed to be the recipe for platinum_block > platinum_ingots so I adjusted it.