### PR TITLE
Make mod spawn eggs compatible with other mods

### DIFF
--- a/src/main/java/com/github/wolfshotz/wyrmroost/items/LazySpawnEggItem.java
+++ b/src/main/java/com/github/wolfshotz/wyrmroost/items/LazySpawnEggItem.java
@@ -1,39 +1,43 @@
 package com.github.wolfshotz.wyrmroost.items;
 
-import com.github.wolfshotz.wyrmroost.entities.dragon.AbstractDragonEntity;
-import com.github.wolfshotz.wyrmroost.entities.dragonegg.DragonEggProperties;
-import com.github.wolfshotz.wyrmroost.registry.WRItems;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.FlowingFluidBlock;
-import net.minecraft.entity.*;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUseContext;
-import net.minecraft.stats.Stats;
-import net.minecraft.tileentity.MobSpawnerTileEntity;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.*;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.BlockRayTraceResult;
-import net.minecraft.util.math.RayTraceContext;
-import net.minecraft.util.math.RayTraceResult;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.TranslationTextComponent;
-import net.minecraft.world.World;
-import net.minecraft.world.server.ServerWorld;
-import net.minecraft.world.spawner.AbstractSpawner;
-import net.minecraftforge.common.util.Lazy;
-import net.minecraftforge.registries.ForgeRegistries;
-
-import javax.annotation.Nullable;
 import java.util.HashSet;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-public class LazySpawnEggItem extends Item
+import javax.annotation.Nullable;
+
+import com.github.wolfshotz.wyrmroost.Wyrmroost;
+import com.github.wolfshotz.wyrmroost.entities.dragon.AbstractDragonEntity;
+import com.github.wolfshotz.wyrmroost.entities.dragonegg.DragonEggProperties;
+import com.github.wolfshotz.wyrmroost.registry.WRItems;
+
+import net.minecraft.entity.AgeableEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.SpawnEggItem;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@EventBusSubscriber(modid = Wyrmroost.MOD_ID, bus = Bus.MOD)
+public class LazySpawnEggItem extends SpawnEggItem
 {
     public static Set<LazySpawnEggItem> EGG_TYPES = new HashSet<>();
     public final Lazy<EntityType<?>> type;
@@ -41,13 +45,39 @@ public class LazySpawnEggItem extends Item
 
     public LazySpawnEggItem(Supplier<EntityType<? extends Entity>> type, int primaryColor, int secondaryColor)
     {
-        super(WRItems.builder());
+        super(null, primaryColor, secondaryColor, WRItems.builder());
 
         this.type = Lazy.of(type);
         this.PRIMARY_COLOR = primaryColor;
         this.SECONDARY_COLOR = secondaryColor;
         EGG_TYPES.add(this);
     }
+    
+	// Use reflection to add the mod spawn eggs to the EGGS map in SpawnEggItem
+	@SubscribeEvent
+	public static void setup(FMLCommonSetupEvent event) {
+		event.enqueueWork(() -> {
+			try {
+			Map<EntityType<?>, SpawnEggItem> eggs = ObfuscationReflectionHelper.getPrivateValue(SpawnEggItem.class,
+					null, "field_195987_b");
+			for (LazySpawnEggItem egg : EGG_TYPES)
+				eggs.put(egg.type.get(), egg);
+			} catch (Exception e) {
+				Wyrmroost.LOG.warn("Unable to access SpawnEggItem.EGGS");
+			} 
+		});
+	}
+    
+	@Override
+	public EntityType<?> getType(CompoundNBT nbt) {
+		if (nbt != null && nbt.contains("EntityTag", 10)) {
+			CompoundNBT compoundnbt = nbt.getCompound("EntityTag");
+			if (compoundnbt.contains("id", 8)) {
+				return EntityType.byKey(compoundnbt.getString("id")).orElse(type.get());
+			}
+		}
+		return type.get();
+	}
 
     @Override
     public ITextComponent getDisplayName(ItemStack stack)
@@ -58,68 +88,6 @@ public class LazySpawnEggItem extends Item
                 .append(new TranslationTextComponent("item.wyrmroost.spawn_egg"));
     }
 
-    public ActionResultType onItemUse(ItemUseContext context)
-    {
-        World world = context.getWorld();
-        if (world.isRemote) return ActionResultType.SUCCESS;
-
-        ItemStack itemstack = context.getItem();
-        BlockPos blockpos = context.getPos();
-        Direction direction = context.getFace();
-        BlockState blockstate = world.getBlockState(blockpos);
-        if (blockstate.getBlock() == Blocks.SPAWNER)
-        {
-            TileEntity tileentity = world.getTileEntity(blockpos);
-            if (tileentity instanceof MobSpawnerTileEntity)
-            {
-                AbstractSpawner abstractspawner = ((MobSpawnerTileEntity) tileentity).getSpawnerBaseLogic();
-                abstractspawner.setEntityType(type.get());
-                tileentity.markDirty();
-                world.notifyBlockUpdate(blockpos, blockstate, blockstate, 3);
-                itemstack.shrink(1);
-                return ActionResultType.SUCCESS;
-            }
-        }
-        
-        BlockPos blockpos1;
-        if (blockstate.getCollisionShape(world, blockpos).isEmpty()) blockpos1 = blockpos;
-        else blockpos1 = blockpos.offset(direction);
-        
-        if (type.get().spawn((ServerWorld) world, itemstack, context.getPlayer(), blockpos1, SpawnReason.SPAWN_EGG, true, !Objects.equals(blockpos, blockpos1) && direction == Direction.UP) != null)
-            itemstack.shrink(1);
-        
-        return ActionResultType.SUCCESS;
-    }
-    
-    public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn)
-    {
-        ItemStack itemstack = playerIn.getHeldItem(handIn);
-        
-        if (worldIn.isRemote) return new ActionResult<>(ActionResultType.PASS, itemstack);
-        
-        BlockRayTraceResult raytraceresult = rayTrace(worldIn, playerIn, RayTraceContext.FluidMode.SOURCE_ONLY);
-        
-        if (raytraceresult.getType() != RayTraceResult.Type.BLOCK)
-            return new ActionResult<>(ActionResultType.PASS, itemstack);
-
-        BlockPos blockpos = raytraceresult.getPos();
-        
-        if (!(worldIn.getBlockState(blockpos).getBlock() instanceof FlowingFluidBlock))
-            return new ActionResult<>(ActionResultType.PASS, itemstack);
-        
-        if (worldIn.isBlockModifiable(playerIn, blockpos) && playerIn.canPlayerEdit(blockpos, raytraceresult.getFace(), itemstack))
-        {
-            if (type.get().spawn((ServerWorld) worldIn, itemstack, playerIn, blockpos, SpawnReason.SPAWN_EGG, false, false) == null)
-                return new ActionResult<>(ActionResultType.PASS, itemstack);
-            if (!playerIn.abilities.isCreativeMode) itemstack.shrink(1);
-            
-            playerIn.addStat(Stats.ITEM_USED.get(this));
-            return new ActionResult<>(ActionResultType.SUCCESS, itemstack);
-        }
-        
-        return new ActionResult<>(ActionResultType.FAIL, itemstack);
-    }
-    
     @Override
     public ActionResultType itemInteractionForEntity(ItemStack stack, PlayerEntity playerIn, LivingEntity target, Hand hand)
     {


### PR DESCRIPTION
A user of one of my mods notified me of the fact that my mod can not create spawn eggs from entities from this mod. It turns out that this is because of the way this mod works around the vanilla SpawnEggItem class. This pull request is a fix for this problem.

This commit changes the LazySpawnEggItem to extends the vanilla
SpawnEggItem class. Also, the mod spawn eggs are added to the
SpawnEggItem.EGGS map via the FMLCommonSetupEvent. This means that some
duplicated code can be removed from the LazySpawnEggItem class, and more
importantly, this mods items are now in the vanilla EGGS map, which
means that other mods can find them.